### PR TITLE
Fix pcis_loopback_test file list

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/verif/scripts/Makefile
+++ b/hdk/cl/examples/cl_wiredancer/verif/scripts/Makefile
@@ -22,6 +22,12 @@ endif
 
 include $(HDK_COMMON_DIR)/verif/tb/scripts/Makefile.header.inc
 
+# Disable automatic generation of simulator file lists so that the
+# manually maintained `top.xsim.f` file is used. This prevents unused
+# design files such as `top_f2.sv.bak` from being compiled when running
+# simple simulations like the PCIS loopback test.
+export DONT_GENERATE_FILE_LIST := 1
+
 # Provide the path to the instruction ROM MIF used by the small
 # soft CPU in cl_wiredancer.  The synthesis flow passes this define
 # via the tcl script; simulation needs it as well.

--- a/hdk/cl/examples/cl_wiredancer/verif/scripts/top.xsim.f
+++ b/hdk/cl/examples/cl_wiredancer/verif/scripts/top.xsim.f
@@ -27,55 +27,8 @@
 
 -include $CL_DIR/design/
 
-$CL_DIR/design/areset_sync.sv
-$CL_DIR/design/schl_cpu_instr_rom.sv
-$CL_DIR/design/ed25519_sub_modp.sv
-$CL_DIR/design/sha512_modq_meta.sv
-$CL_DIR/design/ed25519_sigverify_1.sv
-$CL_DIR/design/cl_vio.sv
-$CL_DIR/design/ed25519_add_modp.sv
-$CL_DIR/design/ed25519_sigverify_ecc.sv
-$CL_DIR/design/schl_cpu.sv
-$CL_DIR/design/sha512_block.sv
-$CL_DIR/design/ed25519_mul_modp.sv
-$CL_DIR/design/top_f2.sv.bak
-$CL_DIR/design/cl_ocl_slv.sv
-$CL_DIR/design/cl_tst_scrb.sv
-$CL_DIR/design/cl_tst.sv
-$CL_DIR/design/dma_result.sv
-$CL_DIR/design/cl_int_tst.sv
-$CL_DIR/design/tid_inorder.sv
-$CL_DIR/design/cl_int_slv.sv
-$CL_DIR/design/cl_dram_dma_axi_mstr.sv
-$CL_DIR/design/dual_clock_showahead_fifo.sv
-$CL_DIR/design/cl_dram_dma_pkg.sv
-$CL_DIR/design/ed25519_point_dbl.sv
-$CL_DIR/design/mul_wide.sv
-$CL_DIR/design/showahead_fifo.sv
-$CL_DIR/design/wd_pkg.sv
-$CL_DIR/design/cl_pcim_mstr.sv
-$CL_DIR/design/cl_dma_pcis_slv.sv
-$CL_DIR/design/ed25519_sigverify_2.sv
-$CL_DIR/design/sha512_msgseq.sv
-$CL_DIR/design/ed25519_sigverify_0.sv
-$CL_DIR/design/sha512_modq.sv
-$CL_DIR/design/ed25519_sigverify_dsdp_mul.sv
-$CL_DIR/design/pcie_inorder.sv
-$CL_DIR/design/axil_slave.sv
-$CL_DIR/design/simple_dual_port_ram.sv
-$CL_DIR/design/cl_dram_dma.sv
-$CL_DIR/design/cl_sda_slv.sv
-$CL_DIR/design/ed25519_point_add.sv
-$CL_DIR/design/mem_scrb.sv
-$CL_DIR/design/sha512_round.sv
-$CL_DIR/design/pcie_tr_ext.sv
-$CL_DIR/design/key_store.sv
-$CL_DIR/design/cl_ila.sv
-$CL_DIR/design/cl_wiredancer.sv.bak
 $CL_DIR/design/cl_wiredancer.sv
-$CL_DIR/design/schl_cpu_instr_rom.mif
-$CL_DIR/design/sha512_pre.sv
-$CL_DIR/design/sha512_sch.sv
+$CL_DIR/design/cl_id_defines.vh
 
 ##### END AUTO-GENERATE ######
 ##############################


### PR DESCRIPTION
## Summary
- avoid regenerating the simulator file lists for cl_wiredancer
- keep only the required design files for xsim

## Testing
- `make pcis_loopback_test XSIM=1` *(fails: cp: cannot stat '/data/xsim/xsim.ini': No such file or directory)*