### PR TITLE
Initialize PCIM DMA registers

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/design/cl_wiredancer.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/cl_wiredancer.sv
@@ -452,6 +452,8 @@ always_ff @(posedge clk) begin
         aw_active   <= 1'b0;
         cur_addr    <= 64'd0;
         beats_left  <= 8'd0;
+        dma_push_a  <= 64'd0;
+        dma_push_d  <= 256'd0;
     end else begin
         if (st_p) begin
             dma_push   <= 1'b1;


### PR DESCRIPTION
## Summary
- zero DMA write address/data registers on reset to avoid X-propagation

## Testing
- `make -C verif/scripts pcis_loopback_test SIMULATOR=xsim` *(fails: Environment variable VIVADO_TOOL_VERSION not set)*