### PR TITLE
Improve DMA signal names for clarity

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/design/cl_wiredancer.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/cl_wiredancer.sv
@@ -361,12 +361,12 @@ assign st_p = st_addr_v & st_data_v;
 // Minimal bridging to PCIM master interface
 ////////////////////////////////////////////////////////////////////////
 
-logic        dma_push;
-logic        dma_r;
-logic        dma_full_a, dma_full_d;
-logic [63:0] dma_push_a;   // addresses
-logic [63:0] dma_push_b;   // unused (WSTRB not needed now)
-logic [255:0] dma_push_d;  // 256-bit data chunk
+logic        dma_push_valid;
+logic        dma_push_ready;
+logic        dma_addr_fifo_full, dma_data_fifo_full;
+logic [63:0] dma_push_addr;   // addresses
+logic [63:0] dma_push_wstrb;  // unused (WSTRB not needed now)
+logic [255:0] dma_push_data;  // 256-bit data chunk
 
 // --------------------------------------------------------------------
 // FIFO Handshake Logic
@@ -402,9 +402,9 @@ showahead_fifo #(
 ) dma_addr_fifo_inst (
     .aclr          (rst),
     .wr_clk        (clk),
-    .wr_req        (dma_push & dma_r),
-    .wr_full       (dma_full_a),
-    .wr_data       (dma_push_a),
+    .wr_req        (dma_push_valid & dma_push_ready),
+    .wr_full       (dma_addr_fifo_full),
+    .wr_data       (dma_push_addr),
     .rd_clk        (clk),
     .rd_req        (pcim_fifo_dequeue),
     .rd_empty      (),
@@ -420,11 +420,11 @@ showahead_fifo #(
 ) dma_data_fifo_inst (
     .aclr          (rst),
     .wr_clk        (clk),
-    .wr_req        (dma_push & dma_r),
-    .wr_full       (dma_full_d),
+    .wr_req        (dma_push_valid & dma_push_ready),
+    .wr_full       (dma_data_fifo_full),
     .wr_full_b     (),
     .wr_count      (),
-    .wr_data       (dma_push_d),
+    .wr_data       (dma_push_data),
     .rd_clk        (clk),
     .rd_req        (pcim_fifo_dequeue),
     .rd_empty      (),
@@ -436,7 +436,7 @@ showahead_fifo #(
 // --------------------------------------------------------------------
 // Push logic from staging FIFO to PCIM write pipeline
 // --------------------------------------------------------------------
-assign dma_r     = ~dma_full_a & ~dma_full_d;
+assign dma_push_ready     = ~dma_addr_fifo_full & ~dma_data_fifo_full;
 
 // Dequeue only when both AW and W channels are ready
 assign pcim_fifo_dequeue = pcim_awvalid && pcim_wvalid &&
@@ -476,12 +476,12 @@ assign cl_sh_pcim_wvalid  = pcim_wvalid;
     .pcie_d(st_data),
 
     // Example DMA push
-    .dma_r             (dma_r),
-    .dma_v             (dma_push),
-    .dma_a             (dma_push_a),
-    .dma_b             (dma_push_b),
-    .dma_f             (dma_full_a | dma_full_d),
-    .dma_d             (dma_push_d),
+    .dma_push_ready    (dma_push_ready),
+    .dma_push_valid    (dma_push_valid),
+    .dma_push_addr     (dma_push_addr),
+    .dma_push_wstrb    (dma_push_wstrb),
+    .dma_fifo_full     (dma_addr_fifo_full | dma_data_fifo_full),
+    .dma_push_data     (dma_push_data),
 
     .dbg_wire          (dbg_wires[0]),
 

--- a/hdk/cl/examples/cl_wiredancer/design/dma_result.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/dma_result.sv
@@ -5,12 +5,12 @@ import wd_sigverify::*;
 module dma_result #(
     N_PCIE                                              = 2
 ) (
-    input wire [1-1:0]                                  dma_r,
-    output logic [1-1:0]                                dma_v,
-    output logic [64-1:0]                               dma_a,
-    output logic [64-1:0]                               dma_b,
-    input wire [1-1:0]                                  dma_f,
-    output logic [256-1:0]                              dma_d,
+    input wire [1-1:0]                                  dma_push_ready,
+    output logic [1-1:0]                                dma_push_valid,
+    output logic [64-1:0]                               dma_push_addr,
+    output logic [64-1:0]                               dma_push_wstrb,
+    input wire [1-1:0]                                  dma_fifo_full,
+    output logic [256-1:0]                              dma_push_data,
 
     input wire [N_PCIE-1:0][1-1:0]                      ext_v,
     input wire [N_PCIE-1:0][1-1:0]                      ext_r,
@@ -39,7 +39,7 @@ mcache_pcim_t [N_PCIE-1:0]              dma_p_dab;
 
 logic [64-1:0]                          dma_aa;
 
-assign dma_a                            = {dma_aa[64-1:6], 6'h0};
+assign dma_push_addr                    = {dma_aa[64-1:6], 6'h0};
 
 generate
 
@@ -131,10 +131,10 @@ rrb_merge #(
     .i_e                                ({N_PCIE{1'b1}}),
     .i_m                                (dma_p_dab),
 
-    .o_r                                (dma_r),
-    .o_v                                (dma_v),
+    .o_r                                (dma_push_ready),
+    .o_v                                (dma_push_valid),
     .o_e                                (),
-    .o_m                                ({dma_d, dma_b, dma_aa}),
+    .o_m                                ({dma_push_data, dma_push_wstrb, dma_aa}),
 
     .clk                                (clk),
     .rst                                (rst)
@@ -145,8 +145,8 @@ if (|dma_p_v)
 $display("%t: %m: %b %b - %b %b", $time
 , dma_p_r
 , dma_p_v
-, dma_r
-, dma_v
+, dma_push_ready
+, dma_push_valid
 );
 endmodule
 

--- a/hdk/cl/examples/cl_wiredancer/design/top_f2.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/top_f2.sv
@@ -56,12 +56,12 @@ module top_f2 #(
     input wire [64-1:0]                                 pcie_a,
     input wire [2-1:0][256-1:0]                         pcie_d,
 
-    input wire [1-1:0]                                  dma_r,
-    output logic [1-1:0]                                dma_v,
-    output logic [64-1:0]                               dma_a,
-    output logic [64-1:0]                               dma_b,
-    input wire [1-1:0]                                  dma_f,
-    output logic [256-1:0]                              dma_d,
+    input wire [1-1:0]                                  dma_push_ready,
+    output logic [1-1:0]                                dma_push_valid,
+    output logic [64-1:0]                               dma_push_addr,
+    output logic [64-1:0]                               dma_push_wstrb,
+    input wire [1-1:0]                                  dma_fifo_full,
+    output logic [256-1:0]                              dma_push_data,
 
     output logic [DBG_WIDTH-1:0]                        dbg_wire,
 
@@ -412,12 +412,12 @@ dma_result #(
     .N_PCIE                     (N_PCIE)
 ) dma_result_inst (
 
-    .dma_r                      (dma_r),
-    .dma_v                      (dma_v),
-    .dma_a                      (dma_a),
-    .dma_b                      (dma_b),
-    .dma_f                      (dma_f),
-    .dma_d                      (dma_d),
+    .dma_push_ready             (dma_push_ready),
+    .dma_push_valid             (dma_push_valid),
+    .dma_push_addr              (dma_push_addr),
+    .dma_push_wstrb             (dma_push_wstrb),
+    .dma_fifo_full              (dma_fifo_full),
+    .dma_push_data              (dma_push_data),
 
     .ext_v                      (ext_v),
     .ext_r                      (ext_r),


### PR DESCRIPTION
## Summary
- rename ambiguous DMA handshake signals for clarity
- update wiredancer example modules to use descriptive names

## Testing
- `make -C hdk/cl/examples/cl_wiredancer/software/runtime help` *(fails: SDK_DIR is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f71e004832396a14b0774965657