### PR TITLE
Fix wiredancer Pblock

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/build/constraints/small_shell_cl_pnr_user.xdc
+++ b/hdk/cl/examples/cl_wiredancer/build/constraints/small_shell_cl_pnr_user.xdc
@@ -100,9 +100,9 @@ resize_pblock pblock_CL_SLR0 -add {SLICE_X221Y60:SLICE_X232Y119 \
                                    GTYE4_COMMON_X1Y1:GTYE4_COMMON_X1Y1 \
                                    GTYE4_CHANNEL_X1Y4:GTYE4_CHANNEL_X1Y7}
 
+
 set_property parent pblock_CL [get_pblocks pblock_CL_SLR0]
 
-resize_pblock [get_pblocks pblock_CL] -add {CLOCKREGION_X0Y0:CLOCKREGION_X7Y11}
 
 ########################################
 # Wiredancer


### PR DESCRIPTION
## Summary
- correct floorplan constraints for `cl_wiredancer` example

## Testing
- `git show -U3`

------
https://chatgpt.com/codex/tasks/task_e_683f775006908323897026c8ef4feb57