### PR TITLE
Fix wiredancer SLR2 pblock range

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/build/constraints/small_shell_cl_pnr_user.xdc
+++ b/hdk/cl/examples/cl_wiredancer/build/constraints/small_shell_cl_pnr_user.xdc
@@ -27,7 +27,8 @@
 create_pblock pblock_CL_SLR2
 
 # Complete CRs in SLR2
-resize_pblock pblock_CL_SLR2 -add {CLOCKREGION_X0Y8:CLOCKREGION_X7Y11}
+# Match the parent pblock width to avoid DRC errors
+resize_pblock pblock_CL_SLR2 -add {CLOCKREGION_X0Y8:CLOCKREGION_X5Y11}
 
 set_property parent pblock_CL [get_pblocks pblock_CL_SLR2]
 


### PR DESCRIPTION
## Summary
- narrow SLR2 pblock width in small shell constraints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fb6ee3c748323b8c59dfe8d60184f