### PR TITLE
Allow placer to spread cl_wiredancer

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/build/constraints/small_shell_cl_pnr_user.xdc
+++ b/hdk/cl/examples/cl_wiredancer/build/constraints/small_shell_cl_pnr_user.xdc
@@ -131,6 +131,8 @@ add_cells_to_pblock [get_pblocks pblock_CL_SLR0] [get_cells -hierarchical -filte
 add_cells_to_pblock [get_pblocks pblock_CL_SLR0] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/cl_wiredancer/vdip_*}]
 add_cells_to_pblock [get_pblocks pblock_CL_SLR0] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/cl_wiredancer/bresp_status}]
 
-# Consolidate all `top_inst` modules to SLR1 unless overridden by functionality
-add_cells_to_pblock [get_pblocks pblock_CL_SLR1] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/top_inst*}]
+# Previously all `top_inst` modules were forced into SLR1. This can lead to
+# placement failures due to resource pressure. Allow Vivado to distribute the
+# logic across SLRs by not constraining these modules to SLR1.
+#add_cells_to_pblock [get_pblocks pblock_CL_SLR1] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/top_inst*}]
 

--- a/hdk/cl/examples/cl_wiredancer/build/constraints/xdma_shell_cl_pnr_user.xdc
+++ b/hdk/cl/examples/cl_wiredancer/build/constraints/xdma_shell_cl_pnr_user.xdc
@@ -168,5 +168,8 @@ add_cells_to_pblock [get_pblocks pblock_CL_SLR0] [get_cells -hierarchical -filte
 add_cells_to_pblock [get_pblocks pblock_CL_SLR0] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/cl_wiredancer/vdip_*}]
 add_cells_to_pblock [get_pblocks pblock_CL_SLR0] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/cl_wiredancer/bresp_status}]
 
-# Consolidate all `top_inst` modules to SLR1 unless overridden by functionality
-add_cells_to_pblock [get_pblocks pblock_CL_SLR1] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/top_inst*}]
+# Previously the entire `top_inst` hierarchy was constrained to SLR1, which
+# can cause placement failures when the available resources are insufficient.
+# Commenting out this constraint allows Vivado to distribute the logic across
+# available SLRs.
+#add_cells_to_pblock [get_pblocks pblock_CL_SLR1] [get_cells -hierarchical -filter {NAME =~ WRAPPER/CL/top_inst*}]


### PR DESCRIPTION
## Summary
- relax placement constraints for `cl_wiredancer`

## Testing
- `make -C hdk/cl/examples/cl_wiredancer/software/runtime` *(fails: SDK_DIR is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684060973fa48323be5c3bc17fedab49