### PR TITLE
Rename cryptic signals

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/design/dma_result.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/dma_result.sv
@@ -12,17 +12,17 @@ module dma_result #(
     input wire [1-1:0]                                  dma_fifo_full,
     output logic [256-1:0]                              dma_push_data,
 
-    input wire [PCIE_N-1:0][1-1:0]                      ext_v,
-    input wire [PCIE_N-1:0][1-1:0]                      ext_r,
-    input wire [PCIE_N-1:0][1-1:0]                      ext_e,
-    input wire [PCIE_N-1:0][$bits(pcie_meta_t)-1:0]     ext_m,
+    input wire [PCIE_N-1:0][1-1:0]                      ext_valid,
+    input wire [PCIE_N-1:0][1-1:0]                      ext_ready,
+    input wire [PCIE_N-1:0][1-1:0]                      ext_eop,
+    input wire [PCIE_N-1:0][$bits(pcie_meta_t)-1:0]     ext_meta,
 
-    input wire [PCIE_N-1:0][1-1:0]                      res_v,
-    input wire [PCIE_N-1:0][64-1:0]                     res_t,
-    input wire [PCIE_N-1:0][1-1:0]                      res_d,
-    output logic [PCIE_N-1:0][16-1:0]                   res_c,
-    output logic [PCIE_N-1:0][1-1:0]                    res_f,
-    output logic [PCIE_N-1:0][1-1:0]                    res_p,
+    input wire [PCIE_N-1:0][1-1:0]                      result_valid,
+    input wire [PCIE_N-1:0][64-1:0]                     result_tid,
+    input wire [PCIE_N-1:0][1-1:0]                      result_data,
+    output logic [PCIE_N-1:0][16-1:0]                   result_count,
+    output logic [PCIE_N-1:0][1-1:0]                    result_full,
+    output logic [PCIE_N-1:0][1-1:0]                    result_push,
 
     input wire [64-1:0]                                 priv_base,
     input wire [64-1:0]                                 priv_mask,
@@ -45,39 +45,39 @@ generate
 
     for (genvar g_i = 0; g_i < PCIE_N; g_i ++) begin: P_IN
 
-        logic [1-1:0]                       ext_p_v, ext_pp_v;
-        pcie_meta_t                         ext_p_m, ext_pp_m;
+        logic [1-1:0]                       ext_pipe_valid, ext_pipe_valid2;
+        pcie_meta_t                         ext_pipe_meta, ext_pipe_meta2;
 
-        logic [1-1:0]                       dma_m_v;
-        logic [16-1:0]                      dma_m_ctrl;
-        logic [1-1:0]                       res_o_v;
-        logic [1-1:0]                       res_o_d;
+        logic [1-1:0]                       dma_meta_valid;
+        logic [16-1:0]                      dma_meta_ctrl;
+        logic [1-1:0]                       result_out_valid;
+        logic [1-1:0]                       result_out_data;
 
-        assign dma_port_valid[g_i]                 = res_o_v & dma_m_v & (|dma_port_desc[g_i].pcim_addr) & (send_fails | res_o_d);
+        assign dma_port_valid[g_i]                 = result_out_valid & dma_meta_valid & (|dma_port_desc[g_i].pcim_addr) & (send_fails | result_out_data);
         assign dma_port_desc[g_i].pcim_strb     = dma_port_desc[g_i].pcim_addr[5] ? 64'hFFFF_FFFF_0000_0000 : 64'h0000_0000_FFFF_FFFF;
-        assign dma_port_desc[g_i].ctrl[1:0]     = dma_m_ctrl[1:0];
-        assign dma_port_desc[g_i].ctrl[2]       = ~res_o_d;
-        assign dma_port_desc[g_i].ctrl[15:3]    = dma_m_ctrl[15:3];
+        assign dma_port_desc[g_i].ctrl[1:0]     = dma_meta_ctrl[1:0];
+        assign dma_port_desc[g_i].ctrl[2]       = ~result_out_data;
+        assign dma_port_desc[g_i].ctrl[15:3]    = dma_meta_ctrl[15:3];
         assign dma_port_desc[g_i].tsorig        = '0;
         assign dma_port_desc[g_i].tspub         = '0;
 
         always_ff@(posedge clk) res_p [g_i] <= dma_port_ready[g_i] & dma_port_valid[g_i];
 
         (* dont_touch = "yes" *) piped_wire #(
-            .WIDTH                      ($bits({ext_m[g_i], ext_v[g_i] & ext_r[g_i] & ext_e[g_i]})),
+            .WIDTH                      ($bits({ext_meta[g_i], ext_valid[g_i] & ext_ready[g_i] & ext_eop[g_i]})),
             .DEPTH                      (2)
         ) ext_pipe_inst (
-            .in                         ({ext_m[g_i], ext_v[g_i] & ext_r[g_i] & ext_e[g_i]}),
-            .out                        ({ext_p_m, ext_p_v}),
+            .in                         ({ext_meta[g_i], ext_valid[g_i] & ext_ready[g_i] & ext_eop[g_i]}),
+            .out                        ({ext_pipe_meta, ext_pipe_valid}),
 
             .clk                        (clk),
             .reset                      (rst)
         );
 
         always_ff@(posedge clk) begin
-            ext_pp_v                    <= ext_p_v;
-            ext_pp_m                    <= ext_p_m;
-            ext_pp_m.dma_addr           <= (ext_p_m.dma_addr & priv_mask) + priv_base;
+            ext_pipe_valid2             <= ext_pipe_valid;
+            ext_pipe_meta2              <= ext_pipe_meta;
+            ext_pipe_meta2.dma_addr     <= (ext_pipe_meta.dma_addr & priv_mask) + priv_base;
         end
 
         showahead_fifo #(
@@ -91,29 +91,29 @@ generate
             .wr_full                    (),
             .wr_full_b                  (),
             .wr_count                   (),
-            .wr_data                    ({ext_pp_m.sig_l[0+:64], ext_pp_m.dma_chunk, ext_pp_m.dma_seq, ext_pp_m.dma_addr, ext_pp_m.dma_ctrl, ext_pp_m.dma_size}),
+            .wr_data                    ({ext_pipe_meta2.sig_l[0+:64], ext_pipe_meta2.dma_chunk, ext_pipe_meta2.dma_seq, ext_pipe_meta2.dma_addr, ext_pipe_meta2.dma_ctrl, ext_pipe_meta2.dma_size}),
 
             .rd_clk                     (clk),
-            .rd_req                     (dma_m_v & res_o_v & dma_port_ready[g_i]),
+            .rd_req                     (dma_meta_valid & result_out_valid & dma_port_ready[g_i]),
             .rd_empty                   (),
-            .rd_not_empty               (dma_m_v),
+            .rd_not_empty               (dma_meta_valid),
             .rd_count                   (),
-            .rd_data                    ({dma_port_desc[g_i].sig, dma_port_desc[g_i].chunk, dma_port_desc[g_i].seq, dma_port_desc[g_i].pcim_addr, dma_m_ctrl, dma_port_desc[g_i].sz})
+            .rd_data                    ({dma_port_desc[g_i].sig, dma_port_desc[g_i].chunk, dma_port_desc[g_i].seq, dma_port_desc[g_i].pcim_addr, dma_meta_ctrl, dma_port_desc[g_i].sz})
         );
 
         tid_inorder #(
             .W                          ($bits({res_d[g_i]})),
             .D                          (2048)
         ) tid_inorder_inst (
-            .i_v                        (res_v      [g_i]),
-            .i_a                        (res_t      [g_i][0+:11]),
-            .i_f                        (res_f      [g_i]),
-            .i_c                        (res_c      [g_i]),
-            .i_d                        (res_d      [g_i]),
+            .in_valid                   (result_valid      [g_i]),
+            .in_addr                    (result_tid        [g_i][0+:11]),
+            .in_full                    (result_full       [g_i]),
+            .in_count                   (result_count      [g_i]),
+            .in_data                    (result_data       [g_i]),
 
-            .o_r                        (dma_m_v & res_o_v & dma_port_ready[g_i]),
-            .o_v                        (res_o_v),
-            .o_d                        (res_o_d),
+            .out_ready                  (dma_meta_valid & result_out_valid & dma_port_ready[g_i]),
+            .out_valid                  (result_out_valid),
+            .out_data                   (result_out_data),
 
             .clk                        (clk),
             .rst                        (rst)

--- a/hdk/cl/examples/cl_wiredancer/design/ed25519_sigverify_0.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/ed25519_sigverify_0.sv
@@ -52,21 +52,21 @@ module ed25519_sigverify_0 #(
     KEY_D                                               = 512,
     KEY_D_L                                             = $clog2(KEY_D)
 ) (
-    output logic [1-1:0]                                i_r, // backpressure
-    input wire [1-1:0]                                  i_w, // wait
-    input wire [1-1:0]                                  i_v,
-    input wire [$bits(sv_meta4_t)-1:0]                  i_m,
+    output logic [1-1:0]                                in_ready, // backpressure
+    input wire [1-1:0]                                  in_wait, // wait
+    input wire [1-1:0]                                  in_valid,
+    input wire [$bits(sv_meta4_t)-1:0]                  in_meta,
 
-    output logic [1-1:0]                                o_v,
-    output logic [$bits(sv_meta5_t)-1:0]                o_m,
+    output logic [1-1:0]                                out_valid,
+    output logic [$bits(sv_meta5_t)-1:0]                out_meta,
 
     input wire clk,
     input wire rst
 );
 
-logic [KEY_D_L-1:0]                                     i_k;
-sv_meta4_t                                              i_mm;
-sv_meta5_t                                              o_mm;
+logic [KEY_D_L-1:0]                                     in_key;
+sv_meta4_t                                              in_meta_reg;
+sv_meta5_t                                              out_meta_reg;
 
 logic [1-1:0]                                           key_i_r;
 logic [1-1:0]                                           key_i_v;
@@ -88,31 +88,31 @@ logic [256-1:0]                                         sch_m_d;
 
 logic [1-1:0]                                           sch_a_v;
 
-assign i_r                                              = |sch_i_r;
-assign i_mm                                             = i_m;
-assign o_m                                              = o_mm;
+assign in_ready                                         = |sch_i_r;
+assign in_meta_reg                                      = in_meta;
+assign out_meta                                         = out_meta_reg;
 
 assign key_i_v                                          = |sch_i_r;
 
 key_store #(
     .D                                                  (KEY_D),
-    .W                                                  ($bits({i_mm}))
+    .W                                                  ($bits({in_meta_reg}))
 ) keystore_inst (
     .i_r                                                (key_i_r),
     .i_v                                                (key_i_v),
-    .i_k                                                (i_k),
-    .i_d                                                ({i_mm}),
+    .i_k                                                (in_key),
+    .i_d                                                ({in_meta_reg}),
 
     .o_r                                                (sch_m_v & (sch_m_a == (N_SCH_O-1))),
     .o_k                                                (sch_m_k),
-    .o_d                                                ({o_mm.m}),
+    .o_d                                                ({out_meta_reg.m}),
 
     .clk                                                (clk),
     .rst                                                (rst)
 );
 
 always_ff@(posedge clk) begin
-    if (i_r)
+    if (in_ready)
         sch_i_rrb                                       <= (sch_i_rrb == N_SCH-1) ? 0 : sch_i_rrb + 1;
     if (rst)
         sch_i_rrb                                       <= 0;
@@ -140,21 +140,21 @@ generate;
                 0: begin
                     if (i_v & (~i_w) & key_i_r & (sch_i_rrb == g_i)) begin
                         sch_ii_v                    <= 1;
-                        sch_ii_k                    <= i_k;
-                        sch_ii_d                    <= i_mm.m.pub;
+                        sch_ii_k                    <= in_key;
+                        sch_ii_d                    <= in_meta_reg.m.pub;
                         sch_ii_st                   <= 1;
                     end
                 end
                 1: begin
                     if (sch_ii_r) begin
-                        sch_ii_d                    <= i_mm.m.sig_l;
+                        sch_ii_d                    <= in_meta_reg.m.sig_l;
                         sch_ii_st                   <= 2;
                     end
                 end
                 2: begin
                     if (sch_ii_r) begin
                         sch_i_r[g_i]                <= 1;
-                        sch_ii_d                    <= i_mm.m.sig_h;
+                        sch_ii_d                    <= in_meta_reg.m.sig_h;
                         sch_ii_st                   <= 3;
                     end
                 end
@@ -275,23 +275,23 @@ generate
 
             .rd_clock                   (clk),
             .rd_address                 (sch_m_k),
-            .q                          (o_mm.os[g_i]),
+            .q                          (out_meta_reg.os[g_i]),
             .rd_en                      (1'b1)
         );
     end
 endgenerate
 
 always_ff@(posedge clk) begin
-    o_v                                             <= sch_m_v & (sch_m_a == (N_SCH_O-1));
-    o_mm.os[N_SCH_O-1]                              <= sch_m_d;
+    out_valid                                       <= sch_m_v & (sch_m_a == (N_SCH_O-1));
+    out_meta_reg.os[N_SCH_O-1]                      <= sch_m_d;
     if (rst)
-        o_v                                         <= 0;
+        out_valid                                   <= 0;
 end
 
-always_ff@(posedge clk) if ((i_v & i_r) | sch_m_v | o_v)
+always_ff@(posedge clk) if ((in_valid & in_ready) | sch_m_v | out_valid)
 $display("%t: %m: %x %x %x %x - %x %x %x %x - %x %x", $time
-    , i_v
-    , i_w
+    , in_valid
+    , in_wait
     , sch_i_rrb
     , sch_i_r
 
@@ -300,8 +300,8 @@ $display("%t: %m: %x %x %x %x - %x %x %x %x - %x %x", $time
     , sch_m_k
     , sch_m_d
 
-    , o_v
-    , o_m
+    , out_valid
+    , out_meta
 );
 
 endmodule

--- a/hdk/cl/examples/cl_wiredancer/design/sha512_modq_meta.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/sha512_modq_meta.sv
@@ -4,22 +4,22 @@ module sha512_modq_meta #(
     parameter integer KEY_D                 = 512,
     parameter integer KEY_D_L               = $clog2(KEY_D)
 ) (
-    output logic [1-1:0]                    i_r, // backpressure is only applied for the first block (i_m.f)
-    input wire [1-1:0]                      i_w, // wait
-    input wire [1-1:0]                      i_v, // valid
-    input wire [1-1:0]                      i_e, // last blk
-    input wire [$bits(sv_meta3_t)-1:0]      i_m, // meta data
+    output logic [1-1:0]                    in_ready, // backpressure is only applied for the first block (in_meta.f)
+    input wire [1-1:0]                      in_wait, // wait
+    input wire [1-1:0]                      in_valid, // valid
+    input wire [1-1:0]                      in_last, // last blk
+    input wire [$bits(sv_meta3_t)-1:0]      in_meta, // meta data
 
-    output logic  [1-1:0]                   o_v,
-    output logic  [1-1:0]                   o_e,
-    output logic  [$bits(sv_meta4_t)-1:0]   o_m,
+    output logic  [1-1:0]                   out_valid,
+    output logic  [1-1:0]                   out_last,
+    output logic  [$bits(sv_meta4_t)-1:0]   out_meta,
 
     input wire [1-1:0] clk,
     input wire [1-1:0] rst
 );
 
-sv_meta3_t                                  i_mm;
-sv_meta4_t                                  o_mm;
+sv_meta3_t                                  in_meta_reg;
+sv_meta4_t                                  out_meta_reg;
 
 logic [1-1:0]                               sha_i_r;
 logic [1-1:0]                               sha_i_v;
@@ -32,34 +32,34 @@ logic [1-1:0]                               sha_o_v;
 logic [KEY_D_L-1:0]                         sha_o_k;
 logic [256-1:0]                             sha_o_d;
 
-assign i_r                                  = (i_mm.f & sha_i_r & key_i_r & ~i_w) | (sha_i_r & ~i_mm.f);
-assign i_mm                                 = i_m;
+assign in_ready                             = (in_meta_reg.f & sha_i_r & key_i_r & ~in_wait) | (sha_i_r & ~in_meta_reg.f);
+assign in_meta_reg                          = in_meta;
 
-assign key_i_v                              = i_mm.f & sha_i_r & i_v & ~i_w;
-assign sha_i_v                              = (i_mm.f & key_i_r & i_v & ~i_w) | (i_v & ~i_mm.f);
+assign key_i_v                              = in_meta_reg.f & sha_i_r & in_valid & ~in_wait;
+assign sha_i_v                              = (in_meta_reg.f & key_i_r & in_valid & ~in_wait) | (in_valid & ~in_meta_reg.f);
 
-assign o_e                                  = 1;
-assign o_m                                  = o_mm;
+assign out_last                             = 1;
+assign out_meta                             = out_meta_reg;
 
 always_ff@(posedge clk) begin
-    o_v                                     <= sha_o_v;
-    o_mm.h                                  <= sha_o_d;
+    out_valid                               <= sha_o_v;
+    out_meta_reg.h                          <= sha_o_d;
     if (rst)
-        o_v <= 0;
+        out_valid <= 0;
 end
 
 key_store #(
     .D                                      (KEY_D),
-    .W                                      ($bits({i_m}))
+    .W                                      ($bits({in_meta}))
 ) keystore_inst (
     .i_r                                    (key_i_r),
     .i_v                                    (key_i_v),
     .i_k                                    (sha_i_k),
-    .i_d                                    ({i_m}),
+    .i_d                                    ({in_meta}),
 
     .o_r                                    (sha_o_v),
     .o_k                                    (sha_o_k),
-    .o_d                                    ({o_mm.m}),
+    .o_d                                    ({out_meta_reg.m}),
 
     .clk                                    (clk),
     .rst                                    (rst)
@@ -68,12 +68,12 @@ key_store #(
 sha512_modq #(
     .META_W                                 (KEY_D_L)
 ) sha512_modq_inst (
-    .i_p                                    (sha_i_r), // backpressure is only applied for the first block (i_m.f)
+    .i_p                                    (sha_i_r), // backpressure is only applied for the first block (in_meta.f)
     .i_v                                    (sha_i_v),
     .i_t                                    (sha_i_k), // key
-    .i_f                                    (i_mm.f), // first blk
-    .i_c                                    (i_mm.c), // number of blocks
-    .i_d                                    (i_mm.d), // data
+    .i_f                                    (in_meta_reg.f), // first blk
+    .i_c                                    (in_meta_reg.c), // number of blocks
+    .i_d                                    (in_meta_reg.d), // data
 
     .o_v                                    (sha_o_v),
     .o_t                                    (sha_o_k),

--- a/hdk/cl/examples/cl_wiredancer/design/tid_inorder.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/tid_inorder.sv
@@ -32,15 +32,15 @@ module tid_inorder #(
     D_L                         = $clog2(D),
     W_L                         = $clog2(W)
 ) (
-    input wire [1-1:0]          i_v,
-    input wire [D_L-1:0]        i_a,
-    input wire [W-1:0]          i_d,
-    output logic [1-1:0]        i_f,
-    output logic [D_L+1-1:0]    i_c,
+    input wire [1-1:0]          in_valid,
+    input wire [D_L-1:0]        in_addr,
+    input wire [W-1:0]          in_data,
+    output logic [1-1:0]        in_full,
+    output logic [D_L+1-1:0]    in_count,
 
-    input wire [1-1:0]          o_r,
-    output logic [1-1:0]        o_v,
-    output logic [W-1:0]        o_d,
+    input wire [1-1:0]          out_ready,
+    output logic [1-1:0]        out_valid,
+    output logic [W-1:0]        out_data,
 
     input wire [1-1:0]          clk,
     input wire [1-1:0]          rst
@@ -55,23 +55,23 @@ logic [W-1:0]                   oo_d;
 logic [D_L-1:0]                 oo_a;
 logic [D_L-1:0]                 oo_a_n;
 
-assign oo_r                     = o_r | ~o_v;
+assign oo_r                     = out_ready | ~out_valid;
 assign oo_a_n                   = (oo_v & oo_r) ? oo_a + 1 : oo_a;
 
-assign i_f                      = i_c >= D-1;
+assign in_full                  = in_count >= D-1;
 assign oo_v                     = (oo_t > last_ts);
 
 simple_dual_port_ram #(
     .WRITE_MODE                                     ("read_first"),
     .CLOCKING_MODE                                  ("common_clock"),
     .ADDRESS_WIDTH                                  (D_L),
-    .DATA_WIDTH                                     ($bits({timestamp, i_d}))
+    .DATA_WIDTH                                     ($bits({timestamp, in_data}))
 ) ram_inst (
     .wr_clock                                       (clk),
-    .wr_address                                     (i_a),
-    .wr_en                                          (i_v),
+    .wr_address                                     (in_addr),
+    .wr_en                                          (in_valid),
     .wr_byteenable                                  ('1),
-    .data                                           ({timestamp, i_d}),
+    .data                                           ({timestamp, in_data}),
 
     .rd_clock                                       (clk),
     .rd_address                                     (oo_a_n),
@@ -102,36 +102,36 @@ always_ff@(posedge clk) begin
     oo_a                        <= oo_a_n;
 
     if (oo_r) begin
-        o_v                     <= oo_v;
-        o_d                     <= oo_d;
+        out_valid               <= oo_v;
+        out_data                <= oo_d;
     end
 
     case({
-        i_v,
-        o_v & o_r
+        in_valid,
+        out_valid & out_ready
     })
-        2'b10: i_c              <= i_c + 1;
-        2'b01: i_c              <= i_c - 1;
+        2'b10: in_count         <= in_count + 1;
+        2'b01: in_count         <= in_count - 1;
     endcase
 
     if (rst) begin
-        i_c                     <= 0;
-        o_v                     <= 0;
+        in_count                <= 0;
+        out_valid               <= 0;
         oo_a                    <= 0;
         timestamp               <= 0;
     end
 end
 
-always_ff@(posedge clk) if (i_v | o_v) $display("%t: %x %x %b %b %x - %x %x %x", $time
-    , i_v
-    , i_a
-    , i_c
-    , i_f
-    , i_d
+always_ff@(posedge clk) if (in_valid | out_valid) $display("%t: %x %x %b %b %x - %x %x %x", $time
+    , in_valid
+    , in_addr
+    , in_count
+    , in_full
+    , in_data
 
-    , o_v
-    , o_r
-    , o_d
+    , out_valid
+    , out_ready
+    , out_data
 );
 
 endmodule

--- a/hdk/cl/examples/cl_wiredancer/design/top_f2.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/top_f2.sv
@@ -420,17 +420,17 @@ dma_result #(
     .dma_fifo_full              (dma_fifo_full),
     .dma_push_data              (dma_push_data),
 
-    .ext_v                      (ext_valid),
-    .ext_r                      (ext_ready),
-    .ext_e                      (ext_eop),
-    .ext_m                      (ext_meta1),
+    .ext_valid                  (ext_valid),
+    .ext_ready                  (ext_ready),
+    .ext_eop                    (ext_eop),
+    .ext_meta                   (ext_meta1),
 
-    .res_v                      (result_valid),
-    .res_t                      (result_tid),
-    .res_d                      (result_data),
-    .res_c                      (result_count),
-    .res_f                      (result_full),
-    .res_p                      (result_push),
+    .result_valid               (result_valid),
+    .result_tid                 (result_tid),
+    .result_data                (result_data),
+    .result_count               (result_count),
+    .result_full                (result_full),
+    .result_push                (result_push),
 
     .send_fails                 (send_fails),
 
@@ -558,15 +558,15 @@ sha512_pre #(
 (* keep_hierarchy = "yes" *) sha512_modq_meta #(
     .KEY_D                                      (KEY_D)
 ) sha512_modq_meta_inst (
-    .i_r                                        (sha_input_ready),
-    .i_w                                        (sha_input_wait),
-    .i_v                                        (sha_input_valid),
-    .i_e                                        (sha_input_eop),
-    .i_m                                        (sha_input_meta),
+    .in_ready                                   (sha_input_ready),
+    .in_wait                                    (sha_input_wait),
+    .in_valid                                   (sha_input_valid),
+    .in_last                                    (sha_input_eop),
+    .in_meta                                    (sha_input_meta),
 
-    .o_v                                        (sha_output_valid),
-    .o_e                                        (),
-    .o_m                                        (sha_output_meta),
+    .out_valid                                  (sha_output_valid),
+    .out_last                                   (),
+    .out_meta                                   (sha_output_meta),
 
     .clk                                        (clk),
     .rst                                        (rst_r[5])
@@ -637,13 +637,13 @@ sha512_pre #(
     .N_SCH                                      (N_SCH),
     .KEY_D                                      (KEY_D)
 ) ed25519_sigverify_0_inst (
-    .i_r                                        (sv0_input_ready),
-    .i_w                                        (sv0_input_wait),
-    .i_v                                        (sv0_input_valid),
-    .i_m                                        (sv0_input_meta),
+    .in_ready                                   (sv0_input_ready),
+    .in_wait                                    (sv0_input_wait),
+    .in_valid                                   (sv0_input_valid),
+    .in_meta                                    (sv0_input_meta),
 
-    .o_v                                        (sv0_output_valid),
-    .o_m                                        (sv0_output_meta),
+    .out_valid                                  (sv0_output_valid),
+    .out_meta                                   (sv0_output_meta),
 
     .clk                                        (clk),
     .rst                                        (rst_r[6])


### PR DESCRIPTION
## Summary
- rename short port names in `sha512_modq_meta.sv`
- rename short port names in `ed25519_sigverify_0.sv`
- rename short port names in `tid_inorder.sv`
- rename short port names in `dma_result.sv`
- update `top_f2.sv` to use the new names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d931d53308323881e78315f4d4686