### PR TITLE
Add PCIM ILA debug module

### DIFF
--- a/hdk/cl/examples/cl_wiredancer/design/cl_ila.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/cl_ila.sv
@@ -1,0 +1,150 @@
+// ============================================================================
+// Amazon FPGA Hardware Development Kit
+//
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License"). You may not use
+// this file except in compliance with the License. A copy of the License is
+// located at
+//
+//    http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+// implied. See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+
+// -----------------------------------------------------------------------------
+// Simple AXI4 bus definition used by the debug cores
+// -----------------------------------------------------------------------------
+interface axi_bus_t #(DATA_WIDTH=512, ADDR_WIDTH=64, ID_WIDTH=16, LEN_WIDTH=8);
+   logic [ID_WIDTH-1:0]   awid;
+   logic [ADDR_WIDTH-1:0] awaddr;
+   logic [LEN_WIDTH-1:0]  awlen;
+   logic [2:0]            awsize;
+   logic                  awvalid;
+   logic                  awready;
+   logic [1:0]            awburst;
+
+   logic [ID_WIDTH-1:0]   wid;
+   logic [DATA_WIDTH-1:0] wdata;
+   logic [DATA_WIDTH/8-1:0] wstrb;
+   logic                  wlast;
+   logic                  wvalid;
+   logic                  wready;
+
+   logic [ID_WIDTH-1:0]   bid;
+   logic [1:0]            bresp;
+   logic                  bvalid;
+   logic                  bready;
+
+   logic [ID_WIDTH-1:0]   arid;
+   logic [ADDR_WIDTH-1:0] araddr;
+   logic [LEN_WIDTH-1:0]  arlen;
+   logic [2:0]            arsize;
+   logic                  arvalid;
+   logic                  arready;
+   logic [1:0]            arburst;
+
+   logic [ID_WIDTH-1:0]   rid;
+   logic [DATA_WIDTH-1:0] rdata;
+   logic [1:0]            rresp;
+   logic                  rlast;
+   logic                  rvalid;
+   logic                  rready;
+endinterface
+
+
+module cl_ila (
+
+   input aclk,
+
+   input drck,
+   input shift,
+   input tdi,
+   input update,
+   input sel,
+   output logic tdo,
+   input tms,
+   input tck,
+   input runtest,
+   input reset,
+   input capture,
+   input bscanid_en,
+
+   axi_bus_t cl_sh_pcim_bus
+
+);
+
+//----------------------------
+// Debug bridge
+//----------------------------
+ cl_debug_bridge CL_DEBUG_BRIDGE (
+      .clk(aclk),
+      .S_BSCAN_drck(drck),
+      .S_BSCAN_shift(shift),
+      .S_BSCAN_tdi(tdi),
+      .S_BSCAN_update(update),
+      .S_BSCAN_sel(sel),
+      .S_BSCAN_tdo(tdo),
+      .S_BSCAN_tms(tms),
+      .S_BSCAN_tck(tck),
+      .S_BSCAN_runtest(runtest),
+      .S_BSCAN_reset(reset),
+      .S_BSCAN_capture(capture),
+      .S_BSCAN_bscanid_en(bscanid_en)
+   );
+
+
+//----------------------------
+// Debug Core ILA for dmm pcis AXI4 interface
+//----------------------------
+   ila_1 CL_DMA_ILA_0 (
+                   .clk    (aclk),
+                   .probe0 (cl_sh_pcim_bus.awvalid),
+                   .probe1 (cl_sh_pcim_bus.awaddr),
+                   .probe2 (2'b0),
+                   .probe3 (cl_sh_pcim_bus.awready),
+                   .probe4 (cl_sh_pcim_bus.wvalid),
+                   .probe5 (cl_sh_pcim_bus.wstrb),
+                   .probe6 (cl_sh_pcim_bus.wlast),
+                   .probe7 (cl_sh_pcim_bus.wready),
+                   .probe8 (1'b0),
+                   .probe9 (1'b0),
+                   .probe10 (cl_sh_pcim_bus.wdata),
+                   .probe11 (1'b0),
+                   .probe12 (cl_sh_pcim_bus.arready),
+                   .probe13 (2'b0),
+                   .probe14 (cl_sh_pcim_bus.rdata),
+                   .probe15 (cl_sh_pcim_bus.araddr),
+                   .probe16 (cl_sh_pcim_bus.arvalid),
+                   .probe17 (3'b0),
+                   .probe18 (3'b0),
+                   .probe19 (cl_sh_pcim_bus.awid),
+                   .probe20 (cl_sh_pcim_bus.arid),
+                   .probe21 (cl_sh_pcim_bus.awlen),
+                   .probe22 (cl_sh_pcim_bus.rlast),
+                   .probe23 (3'b0),
+                   .probe24 (cl_sh_pcim_bus.rresp),
+                   .probe25 (cl_sh_pcim_bus.rid),
+                   .probe26 (cl_sh_pcim_bus.rvalid),
+                   .probe27 (cl_sh_pcim_bus.arlen),
+                   .probe28 (3'b0),
+                   .probe29 (cl_sh_pcim_bus.bresp),
+                   .probe30 (cl_sh_pcim_bus.rready),
+                   .probe31 (4'b0),
+                   .probe32 (4'b0),
+                   .probe33 (4'b0),
+                   .probe34 (4'b0),
+                   .probe35 (cl_sh_pcim_bus.bvalid),
+                   .probe36 (4'b0),
+                   .probe37 (4'b0),
+                   .probe38 (cl_sh_pcim_bus.bid),
+                   .probe39 (cl_sh_pcim_bus.bready),
+                   .probe40 (1'b0),
+                   .probe41 (1'b0),
+                   .probe42 (1'b0),
+                   .probe43 (1'b0)
+                   );
+endmodule

--- a/hdk/cl/examples/cl_wiredancer/design/cl_wiredancer.sv
+++ b/hdk/cl/examples/cl_wiredancer/design/cl_wiredancer.sv
@@ -507,6 +507,57 @@ showahead_fifo #(
     .rd_data       ({cl_sh_pcim_wstrb, cl_sh_pcim_wdata_half})
 );
 
+// --------------------------------------------------------------------
+// ILA hookup for PCIM interface
+// --------------------------------------------------------------------
+axi_bus_t cl_sh_pcim_bus();
+assign cl_sh_pcim_bus.awvalid = cl_sh_pcim_awvalid;
+assign cl_sh_pcim_bus.awaddr  = cl_sh_pcim_awaddr;
+assign cl_sh_pcim_bus.awlen   = cl_sh_pcim_awlen;
+assign cl_sh_pcim_bus.awsize  = cl_sh_pcim_awsize;
+assign cl_sh_pcim_bus.awburst = cl_sh_pcim_awburst;
+assign cl_sh_pcim_bus.awready = sh_cl_pcim_awready;
+assign cl_sh_pcim_bus.wvalid  = cl_sh_pcim_wvalid;
+assign cl_sh_pcim_bus.wstrb   = cl_sh_pcim_wstrb;
+assign cl_sh_pcim_bus.wlast   = cl_sh_pcim_wlast;
+assign cl_sh_pcim_bus.wready  = sh_cl_pcim_wready;
+assign cl_sh_pcim_bus.wdata   = cl_sh_pcim_wdata;
+assign cl_sh_pcim_bus.bid     = sh_cl_pcim_bid;
+assign cl_sh_pcim_bus.bresp   = sh_cl_pcim_bresp;
+assign cl_sh_pcim_bus.bvalid  = sh_cl_pcim_bvalid;
+assign cl_sh_pcim_bus.bready  = cl_sh_pcim_bready;
+assign cl_sh_pcim_bus.arvalid = cl_sh_pcim_arvalid;
+assign cl_sh_pcim_bus.araddr  = cl_sh_pcim_araddr;
+assign cl_sh_pcim_bus.arlen   = cl_sh_pcim_arlen;
+assign cl_sh_pcim_bus.arsize  = cl_sh_pcim_arsize;
+assign cl_sh_pcim_bus.arburst = cl_sh_pcim_arburst;
+assign cl_sh_pcim_bus.arready = sh_cl_pcim_arready;
+assign cl_sh_pcim_bus.rdata   = sh_cl_pcim_rdata;
+assign cl_sh_pcim_bus.rresp   = sh_cl_pcim_rresp;
+assign cl_sh_pcim_bus.rid     = sh_cl_pcim_rid;
+assign cl_sh_pcim_bus.rlast   = sh_cl_pcim_rlast;
+assign cl_sh_pcim_bus.rvalid  = sh_cl_pcim_rvalid;
+assign cl_sh_pcim_bus.rready  = cl_sh_pcim_rready;
+assign cl_sh_pcim_bus.awid    = cl_sh_pcim_awid;
+assign cl_sh_pcim_bus.arid    = cl_sh_pcim_arid;
+
+cl_ila CL_ILA (
+    .aclk          (clk),
+    .drck          (drck),
+    .shift         (shift),
+    .tdi           (tdi),
+    .update        (update),
+    .sel           (sel),
+    .tdo           (tdo),
+    .tms           (tms),
+    .tck           (tck),
+    .runtest       (runtest),
+    .reset         (reset),
+    .capture       (capture),
+    .bscanid_en    (bscanid_en),
+    .cl_sh_pcim_bus(cl_sh_pcim_bus)
+);
+
 ////////////////////////////////////////////////////////////////////////
 // Example “top_f2” instance (from your snippet)
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- add an ILA module for PCIM traffic
- connect debug bridge to PCIM interface in cl_wiredancer

## Testing
- `python3 shared/bin/check_doc_links.py -f docs-rtd/source/hdk/docs/Virtual-JTAG-XVC.rst` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ca7f57a308323881c8154f9706e8c